### PR TITLE
Updated playbook.yml for FF-MPEG location

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -481,7 +481,7 @@
   hosts: ffmpeg-box 
   tasks:
       - name: Download FFmpeg
-        get_url: url=http://johnvansickle.com/ffmpeg/releases/ffmpeg-2.6.1-64bit-static.tar.xz dest=/root/ffmpeg.tar.xz mode=444
+        get_url: url=http://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz dest=/root/ffmpeg.tar.xz mode=444
       - name: Unpack FFmpeg
         unarchive: src=/root/ffmpeg.tar.xz dest=/opt copy=no owner=root group=root creates=/opt/ffmpeg-2.6.1-64bit-static/ffprobe
       - name: Soft-link FFmpeg


### PR DESCRIPTION
Updated the URL for the FF-MPEG location. It appears that he is no longer using release numbered file names and instead has gone with the much better 'release' name instead.
